### PR TITLE
feat(skill): add lip-sync support with text-to-speech and audio modes

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: vidu-skills
 description: Generate video and images by calling the official Vidu API via vidu CLI. Use when the user wants text-to-image (文生图), text-to-video (文生视频), image-to-video (图生视频), head-tail-image-to-video (首尾帧生视频), reference-to-image (参考生图), reference-to-video (参考生视频), lip-sync (口型同步), text-to-speech (文字转语音), Create References (创建参考资料), or to submit or check Vidu tasks. Requires VIDU_TOKEN and optional VIDU_BASE_URL.
-compatibility: Requires vidu-cli ≥ 0.2.4 (install via `npm install -g vidu-cli`). Node.js >=14 required.
+compatibility: Requires vidu-cli latest (install via `npm install -g vidu-cli@latest`). Node.js >=14 required.
 version: 1.4.0
 url: https://www.vidu.cn/
 secrets:
@@ -45,8 +45,7 @@ Generate AI videos and images with Vidu (生数) via `vidu-cli` — text-to-imag
 |---------|---------|
 | `vidu-cli upload <image_path>` | Upload image → `upload_id`, `ssupload_uri` |
 | `vidu-cli task submit --type ... --prompt ... [options]` | Submit task → `task_id`. `--image`: local path, URL, or `ssupload:?id=...` (auto-upload). |
-| `vidu-cli task get <task_id>` | Query task → `state`, `media_urls` when successful |
-| `vidu-cli task sse <task_id>` | Stream SSE state events |
+| `vidu-cli task get <task_id> [--output/-o <dir>]` | Query task → `state`, `type`, `model`; use `--output` to download media on success |
 | `vidu-cli task lip-sync --video <path> --text <text> [options]` | Lip-sync with text-to-speech → `task_id` |
 | `vidu-cli task lip-sync --video <path> --audio <path>` | Lip-sync with audio file → `task_id` |
 | `vidu-cli task lip-sync-voices` | 列出 lip-sync 可用声音（~86个，中/英/粤/卡通等） |
@@ -77,15 +76,15 @@ Generate AI videos and images with Vidu (生数) via `vidu-cli` — text-to-imag
 - **text-to-speech (文字转语音)** — Convert text to speech audio via `task tts`
 - **Create References (创建主体)** — `element create` (single command)
 - **Search Community References (搜索社区主体库)** — `element search`
-- **Query task (查询任务)** — `task get` / `task sse`
+- **Query task (查询任务)** — `task get [--output <dir>]`
 
 ---
 
 ## Setup
 
-1. `npm install -g vidu-cli` (requires Node.js >=14; postinstall auto-downloads the platform binary)
+1. `npm install -g vidu-cli@latest` (requires Node.js >=14; postinstall auto-downloads the platform binary)
 2. Obtain `VIDU_TOKEN` (e.g. Vidu console).
-3. `export VIDU_TOKEN="..."` — required; `export VIDU_BASE_URL=...` if not using default region.
+3. Set `VIDU_TOKEN` environment variable (required); set `VIDU_BASE_URL` if not using default region.
 4. Verify: `vidu-cli task submit --help`
 
 ---
@@ -110,15 +109,15 @@ Content you send (prompts, images, task settings) goes to Vidu’s API. Confirm 
 1. Pick capability → map to `--type` and options using **references/parameters.md** (matrix + validation).
 2. Prepare inputs: for **reference2image** / **character2video**, `--image` and/or `--material` so **combined count is 1–7**; optional `[@name]` in prompt per **references/parameters.md**.
 3. `vidu-cli task submit ...` → store `task_id` and `trace_id`.
-4. `vidu-cli task get <task_id>` until `success` or `failed` (or use `task sse` if appropriate).
-5. On success return `media_urls`; on task failure return `err_code` / `err_msg`; on CLI `ok: false` return `error` fields verbatim.
+4. `vidu-cli task get <task_id>` until `success` or `failed`; use `--output <dir>` to download media on success.
+5. On success return `downloaded_files` (if `--output` used) or prompt user to re-run with `--output`; on task failure return `err_code` / `err_msg`; on CLI `ok: false` return `error` fields verbatim.
 
 ---
 
 ## Output to the user
 
 - After **submit**: return **`task_id`** and **`trace_id`**; state that processing is in progress.
-- After **query**: if `state` is success, return **`media_urls`**; if failed, return **`err_code`** and **`err_msg`** exactly (note: response may still have `ok: true` while `state` is `failed`).
+- After **query**: if `state` is success, return **`downloaded_files`** (if `--output` was used) or the `task_id` with a note to re-run with `--output <dir>` to download; if failed, return **`err_code`** and **`err_msg`** exactly (note: response may still have `ok: true` while `state` is `failed`).
 - On **CLI failure** (`ok: false`): report `error.type`, `http_status`, `code`, `message` exactly — **do not infer causes**.
 
 ---
@@ -134,4 +133,4 @@ Content you send (prompts, images, task settings) goes to Vidu’s API. Confirm 
 
 ## Fallback (no Node.js / npm)
 
-If `node` / `npm` / `vidu-cli` cannot be installed, this skill cannot run. Require **vidu-cli ≥ 0.2.4** (via `npm install -g vidu-cli`, Node.js >=14) and point users to **references/parameters.md** for parameter details.
+If `node` / `npm` / `vidu-cli` cannot be installed, this skill cannot run. Require **vidu-cli latest** (via `npm install -g vidu-cli@latest`, Node.js >=14) and point users to **references/parameters.md** for parameter details.

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: vidu-skills
-description: Generate video and images by calling the official Vidu API via vidu CLI. Use when the user wants text-to-image (文生图), text-to-video (文生视频), image-to-video (图生视频), head-tail-image-to-video (首尾帧生视频), reference-to-image (参考生图), reference-to-video (参考生视频), Create References (创建参考资料), or to submit or check Vidu tasks. Requires VIDU_TOKEN and optional VIDU_BASE_URL.
+description: Generate video and images by calling the official Vidu API via vidu CLI. Use when the user wants text-to-image (文生图), text-to-video (文生视频), image-to-video (图生视频), head-tail-image-to-video (首尾帧生视频), reference-to-image (参考生图), reference-to-video (参考生视频), lip-sync (口型同步), Create References (创建参考资料), or to submit or check Vidu tasks. Requires VIDU_TOKEN and optional VIDU_BASE_URL.
 compatibility: Requires vidu-cli >= 0.2.0 (install via `cargo install vidu-cli`). Set VIDU_TOKEN in the environment; VIDU_BASE_URL optional (default https://service.vidu.cn).
-version: 1.3.1
+version: 1.3.2
 url: https://www.vidu.cn/
 secrets:
   - VIDU_TOKEN
@@ -47,6 +47,9 @@ Generate AI videos and images with Vidu (生数) via `vidu-cli` — text-to-imag
 | `vidu-cli task submit --type ... --prompt ... [options]` | Submit task → `task_id`. `--image`: local path, URL, or `ssupload:?id=...` (auto-upload). |
 | `vidu-cli task get <task_id>` | Query task → `state`, `media_urls` when successful |
 | `vidu-cli task sse <task_id>` | Stream SSE state events |
+| `vidu-cli task lip-sync --video <path> --text <text> [options]` | Lip-sync with text-to-speech → `task_id` |
+| `vidu-cli task lip-sync --video <path> --audio <path>` | Lip-sync with audio file → `task_id` |
+| `vidu-cli task lip-sync-voices` | List all available voice IDs for lip-sync |
 | `vidu-cli element create --name ... --image ... [--description ...] [--style ...]` | Create reference element (check → preprocess → create). Returns `id`, `version`. |
 | `vidu-cli element check --name ...` | Check name availability |
 | `vidu-cli element list [--keyword kw]` | List personal elements |
@@ -68,6 +71,7 @@ Generate AI videos and images with Vidu (生数) via `vidu-cli` — text-to-imag
 - **head-tail-image-to-video (首尾帧生视频)** — Start + end frames + text
 - **reference-to-image (参考生图)** — **Images + materials: 1–7** total; **text prompt required**; can be images-only, materials-only, or mixed; images-only needs no `element create`
 - **reference-to-video (参考生视频)** — Same rule: **1–7** total; **text prompt required**
+- **lip-sync (口型同步)** — Drive video mouth movement with text-to-speech or audio file
 - **Create References (创建主体)** — `element create` (single command)
 - **Search Community References (搜索社区主体库)** — `element search`
 - **Query task (查询任务)** — `task get` / `task sse`

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: vidu-skills
-description: Generate video and images by calling the official Vidu API via vidu CLI. Use when the user wants text-to-image (文生图), text-to-video (文生视频), image-to-video (图生视频), head-tail-image-to-video (首尾帧生视频), reference-to-image (参考生图), reference-to-video (参考生视频), lip-sync (口型同步), Create References (创建参考资料), or to submit or check Vidu tasks. Requires VIDU_TOKEN and optional VIDU_BASE_URL.
-compatibility: Requires vidu-cli >= 0.2.0 (install via `cargo install vidu-cli`). Set VIDU_TOKEN in the environment; VIDU_BASE_URL optional (default https://service.vidu.cn).
-version: 1.3.2
+description: Generate video and images by calling the official Vidu API via vidu CLI. Use when the user wants text-to-image (文生图), text-to-video (文生视频), image-to-video (图生视频), head-tail-image-to-video (首尾帧生视频), reference-to-image (参考生图), reference-to-video (参考生视频), lip-sync (口型同步), text-to-speech (文字转语音), Create References (创建参考资料), or to submit or check Vidu tasks. Requires VIDU_TOKEN and optional VIDU_BASE_URL.
+compatibility: Requires vidu-cli ≥ 0.2.4 (install via `npm install -g vidu-cli`). Node.js >=14 required.
+version: 1.4.0
 url: https://www.vidu.cn/
 secrets:
   - VIDU_TOKEN
 dependencies:
-  - cargo
+  - node
 ---
 
 # Vidu Video and Image Generation Skill (Vidu 音视频/图像生成技能)
@@ -49,7 +49,9 @@ Generate AI videos and images with Vidu (生数) via `vidu-cli` — text-to-imag
 | `vidu-cli task sse <task_id>` | Stream SSE state events |
 | `vidu-cli task lip-sync --video <path> --text <text> [options]` | Lip-sync with text-to-speech → `task_id` |
 | `vidu-cli task lip-sync --video <path> --audio <path>` | Lip-sync with audio file → `task_id` |
-| `vidu-cli task lip-sync-voices` | List all available voice IDs for lip-sync |
+| `vidu-cli task lip-sync-voices` | 列出 lip-sync 可用声音（~86个，中/英/粤/卡通等） |
+| `vidu-cli task tts --prompt ... --voice-id ...` | TTS 文字转语音 → `task_id` |
+| `vidu-cli task tts-voices` | 列出 TTS 可用声音（300+个，20+语言） |
 | `vidu-cli element create --name ... --image ... [--description ...] [--style ...]` | Create reference element (check → preprocess → create). Returns `id`, `version`. |
 | `vidu-cli element check --name ...` | Check name availability |
 | `vidu-cli element list [--keyword kw]` | List personal elements |
@@ -72,6 +74,7 @@ Generate AI videos and images with Vidu (生数) via `vidu-cli` — text-to-imag
 - **reference-to-image (参考生图)** — **Images + materials: 1–7** total; **text prompt required**; can be images-only, materials-only, or mixed; images-only needs no `element create`
 - **reference-to-video (参考生视频)** — Same rule: **1–7** total; **text prompt required**
 - **lip-sync (口型同步)** — Drive video mouth movement with text-to-speech or audio file
+- **text-to-speech (文字转语音)** — Convert text to speech audio via `task tts`
 - **Create References (创建主体)** — `element create` (single command)
 - **Search Community References (搜索社区主体库)** — `element search`
 - **Query task (查询任务)** — `task get` / `task sse`
@@ -80,7 +83,7 @@ Generate AI videos and images with Vidu (生数) via `vidu-cli` — text-to-imag
 
 ## Setup
 
-1. `cargo install vidu-cli`
+1. `npm install -g vidu-cli` (requires Node.js >=14; postinstall auto-downloads the platform binary)
 2. Obtain `VIDU_TOKEN` (e.g. Vidu console).
 3. `export VIDU_TOKEN="..."` — required; `export VIDU_BASE_URL=...` if not using default region.
 4. Verify: `vidu-cli task submit --help`
@@ -129,6 +132,6 @@ Content you send (prompts, images, task settings) goes to Vidu’s API. Confirm 
 
 ---
 
-## Fallback (no Rust / Cargo)
+## Fallback (no Node.js / npm)
 
-If `cargo` / `vidu-cli` cannot be installed, this skill cannot run. Require **vidu-cli ≥ 0.2.0** and point users to **references/parameters.md** for parameter details.
+If `node` / `npm` / `vidu-cli` cannot be installed, this skill cannot run. Require **vidu-cli ≥ 0.2.4** (via `npm install -g vidu-cli`, Node.js >=14) and point users to **references/parameters.md** for parameter details.

--- a/references/errors_and_retry.md
+++ b/references/errors_and_retry.md
@@ -26,7 +26,7 @@ Tell the user the task failed and pass through **`err_code`** / **`err_msg`**. D
 There is **no built-in wait** in the CLI: `vidu-cli task submit` returns `task_id`; the caller runs **`vidu-cli task get <task_id>`** when needed.
 
 - **`vidu-cli task get`** is read-only and safe to repeat (poll until terminal state or timeout).
-- **`vidu-cli task sse <task_id>`** streams state updates; optional alternative to polling.
+- **`vidu-cli task get <task_id> --output <dir>`** downloads media files on success.
 
 ---
 

--- a/references/parameters.md
+++ b/references/parameters.md
@@ -6,7 +6,7 @@ Daily use: **`vidu-cli`** flags and the sections below.
 
 ## Task Support Matrix
 
-| Task Type | `--type` | Model Version | Duration | Resolution | Aspect Ratio | Transition | Images |
+| Task Type | CLI Command | Model Version | Duration | Resolution | Aspect Ratio | Transition | Images |
 |-----------|----------|---------------|----------|------------|--------------|------------|--------|
 | text2image | `text2image` | 3.1, 3.2_fast_m, 3.2_pro_m | 0 | 1080p, 2k, 4k | 4:3, 3:4, 1:1, 9:16, 16:9 | N/A | 0 |
 | text2video | `text2video` | 3.0, 3.1, 3.2 | 3.0: 5s; 3.1: 2–8s; 3.2: 1–16s | 1080p | 16:9, 9:16, 1:1, 4:3, 3:4 | 3.2: pro/speed | 0 |
@@ -15,6 +15,7 @@ Daily use: **`vidu-cli`** flags and the sections below.
 | reference2image | `reference2image` | 3.1, 3.2_fast_m, 3.2_pro_m | 0 | 1080p, 2k, 4k | 4:3, 3:4, 1:1, 9:16, 16:9 | N/A | images + materials: 1–7 |
 | character2video | `character2video` | 3.0, 3.1, 3.1_pro, 3.2 | 3.0: 5s; 3.1: 2–8s; 3.1_pro: -1/2–8s; 3.2: 1–16s | 1080p | 16:9, 9:16, 1:1, 4:3, 3:4 | 3.2: **pro/speed (required)** | images + materials: 1–7 |
 | lip_sync | `task lip-sync` | N/A | auto (from text/audio) | 1080p | from video | N/A | 1 video + (text OR audio) |
+| tts | `task tts` | N/A | auto (from text) | N/A | N/A | N/A | text + voice-id |
 
 **Capability notes**
 
@@ -24,6 +25,7 @@ Daily use: **`vidu-cli`** flags and the sections below.
 - **head-tail-image-to-video**: Two images (start, end) + text.
 - **reference2image (参考生图)** and **character2video (参考生视频)** — same input rule: **image count + material (主体) count must be ≥ 1 and ≤ 7** (each `--image` and each `--material` counts toward the total). **Text prompt (`--prompt`) is required** for both (cannot omit or leave empty).
 - **lip-sync (口型同步)**: Drive video mouth movement with text-to-speech or audio file. Two modes: **text mode** (TTS with voice selection) or **audio mode** (custom audio file). Video: MP4/MOV/AVI, ≤500MB. Audio: MP3/WAV/AAC/M4A, ≤100MB.
+- **TTS (文字转语音)**: Convert text to speech audio. Uses `task tts` command (not `task submit`). Requires `--prompt` and `--voice-id`. List voices with `task tts-voices`.
 - You **do not** need `element create` when using **`--image` only**. Use **`--material`** / `[@name]` when using a saved or community reference element (you may combine images and materials as long as the total stays in 1–7).
 - **Create References**: `vidu-cli element create --name ... --image ...` runs check → preprocess → create; returns element `id` and `version`.
 - **List personal references**: `vidu-cli element list [--keyword kw]`.
@@ -135,7 +137,7 @@ vidu-cli element search --keyword "keyword" [--pagesz 20]
 
 ### `--transition` (optional; video)
 
-- **text2video** (3.0 / 3.2): `pro`, `speed`
+- **text2video** (3.2 only): `pro`, `speed`
 - **text2video** (3.1): do not pass
 - **img2video**, **headtailimg2video**: `pro`, `speed` (3.0: creative/stable per matrix)
 - **character2video** (3.2): `pro`, `speed` (**required** for model version 3.2)
@@ -338,8 +340,8 @@ vidu-cli task lip-sync \
 - Text: Chinese 2–1000 chars, English 4–2000 chars
 - `--text` and `--audio` are mutually exclusive (use one or the other)
 - `--speed`: 0.5–2.0 (default 1.0, text mode only)
-- `--volume`: 0.5–2.0 or 0 for server default (text mode only)
-- `--voice-id`: default `English_Aussie_Bloke` (90+ voices available, see voice list below)
+- `--volume`: 0.1–2.0, or 0 for server default (text mode only)
+- `--voice-id`: default `English_Aussie_Bloke` (90+ voices available, see voice list below). Voice IDs from `lip-sync-voices` only; do not use `tts-voices` IDs here.
 - Duration is auto-calculated from text length or audio file
 
 **Available voice IDs** (partial list, 90+ total):
@@ -357,7 +359,32 @@ vidu-cli task lip-sync-voices
 
 Returns: `{"ok": true, "count": 90+, "voice_ids": [...]}`
 
-### 8. Query task result
+### 8. TTS (Text-to-Speech, 文字转语音)
+
+```bash
+vidu-cli task tts \
+  --prompt "text" \
+  --voice-id "Chinese (Mandarin)_Reliable_Executive" \
+  --speed 1.0 \
+  --volume 80 \
+  --emotion "happy" \
+  --language-boost "Chinese"
+```
+
+| Parameter | Required | Default | Range | Description |
+|-----------|----------|---------|-------|-------------|
+| `--prompt` | Yes | - | 1-2000 chars | Text to convert to speech |
+| `--voice-id` | Yes | - | See tts-voices | Voice ID. Voice IDs from `tts-voices` only; do not use `lip-sync-voices` IDs here. |
+| `--speed` | No | 1.0 | 0.5-2.0 | Speed multiplier |
+| `--volume` | No | 80 | 0-100 | Volume level |
+| `--emotion` | No | - | Any text | Emotion hint |
+| `--language-boost` | No | - | Chinese, English, auto | Enhance specific language recognition |
+
+List available voices: `vidu-cli task tts-voices` (grouped by language with count)
+
+Returns task_id — query result with `task get <task_id>`.
+
+### 9. Query task result
 
 ```bash
 vidu-cli task get "$TASK_ID"
@@ -368,7 +395,7 @@ vidu-cli task get "$TASK_ID"
 - **failed**: `err_code`, `err_msg` — note `ok` may still be `true` with `state: failed`
 - **processing**: poll again later
 
-### 9. Task SSE (optional)
+### 10. Task SSE (optional)
 
 ```bash
 vidu-cli task sse "$TASK_ID"
@@ -376,7 +403,7 @@ vidu-cli task sse "$TASK_ID"
 
 Streams SSE to stdout; may produce large output.
 
-### 10. Image upload (optional)
+### 11. Image upload (optional)
 
 ```bash
 vidu-cli upload /path/to/image.jpg
@@ -445,6 +472,7 @@ Present results with `id`, `version`, `name`, `description`, `category` when ava
 - **head-tail-image-to-video**: Similar frames → smoother transition; very different frames → stronger morph.
 - **reference-to-image / reference-to-video**: **reference2image** and **character2video** both require a **non-empty text prompt**. **Image count + material count** must be **≥ 1 and ≤ 7**. You may use images only, materials only, or a mix; without `element create` when using images only. With a saved or community reference, use `[@reference_name]` and matching `--material`.
 - **lip-sync**: Choose text mode for TTS with voice selection, or audio mode for custom audio. Text mode auto-calculates duration from text length (Chinese: ~5 chars/sec, English: ~10 chars/sec). Audio mode reads duration from audio file metadata. Video must contain visible face/mouth for best results.
+- **TTS**: Use `tts-voices` to find the right voice ID. `--language-boost` helps when mixing languages. `--emotion` provides a hint for expressive speech.
 
 ---
 

--- a/references/parameters.md
+++ b/references/parameters.md
@@ -68,18 +68,12 @@ vidu-cli task submit \
 ### Query task
 
 ```bash
-vidu-cli task get <task_id>
+vidu-cli task get <task_id> [--output/-o <dir>]
 ```
 
-Returns: `state`, `media_urls` (if success), `err_code` / `err_msg` (if failed).
+Returns: `task_id`, `state`, `type`, `model`; on failed: `err_code`, `err_msg`.
 
-### Stream task status (SSE)
-
-```bash
-vidu-cli task sse <task_id>
-```
-
-Streams events to stdout; can be verbose for agents.
+`--output <dir>` (optional): when state is `success`, downloads all media files to `<dir>` and returns `downloaded_files` (list of local paths). If state is not `success`, returns `download_skipped: "task not ready"`.
 
 ### Search community references
 
@@ -391,19 +385,21 @@ vidu-cli task get "$TASK_ID"
 ```
 
 - `state`: `success` | `failed` | `processing` | ...
-- **success**: `media_urls` present
+- Response always includes: `task_id`, `state`, `type`, `model`
 - **failed**: `err_code`, `err_msg` — note `ok` may still be `true` with `state: failed`
 - **processing**: poll again later
 
-### 10. Task SSE (optional)
+Download media on success:
 
 ```bash
-vidu-cli task sse "$TASK_ID"
+vidu-cli task get "$TASK_ID" --output ./downloads
 ```
 
-Streams SSE to stdout; may produce large output.
+- Downloads all media files to `./downloads/` as `{task_id}_{i}.mp4`
+- Returns `downloaded_files` (list of local paths)
+- If not yet `success`: returns `download_skipped: "task not ready"`
 
-### 11. Image upload (optional)
+### 10. Image upload (optional)
 
 ```bash
 vidu-cli upload /path/to/image.jpg

--- a/references/parameters.md
+++ b/references/parameters.md
@@ -14,6 +14,7 @@ Daily use: **`vidu-cli`** flags and the sections below.
 | headtailimg2video | `headtailimg2video` | 3.0, 3.1, 3.2 | 3.0: 5s; 3.1: 2–8s; 3.2: 1–16s | 1080p | N/A | 3.0: creative/stable; 3.1+: pro/speed | exactly 2 |
 | reference2image | `reference2image` | 3.1, 3.2_fast_m, 3.2_pro_m | 0 | 1080p, 2k, 4k | 4:3, 3:4, 1:1, 9:16, 16:9 | N/A | images + materials: 1–7 |
 | character2video | `character2video` | 3.0, 3.1, 3.1_pro, 3.2 | 3.0: 5s; 3.1: 2–8s; 3.1_pro: -1/2–8s; 3.2: 1–16s | 1080p | 16:9, 9:16, 1:1, 4:3, 3:4 | 3.2: **pro/speed (required)** | images + materials: 1–7 |
+| lip_sync | `task lip-sync` | N/A | auto (from text/audio) | 1080p | from video | N/A | 1 video + (text OR audio) |
 
 **Capability notes**
 
@@ -22,6 +23,7 @@ Daily use: **`vidu-cli`** flags and the sections below.
 - **image-to-video**: One image + text; aspect ratio comes from the image.
 - **head-tail-image-to-video**: Two images (start, end) + text.
 - **reference2image (参考生图)** and **character2video (参考生视频)** — same input rule: **image count + material (主体) count must be ≥ 1 and ≤ 7** (each `--image` and each `--material` counts toward the total). **Text prompt (`--prompt`) is required** for both (cannot omit or leave empty).
+- **lip-sync (口型同步)**: Drive video mouth movement with text-to-speech or audio file. Two modes: **text mode** (TTS with voice selection) or **audio mode** (custom audio file). Video: MP4/MOV/AVI, ≤500MB. Audio: MP3/WAV/AAC/M4A, ≤100MB.
 - You **do not** need `element create` when using **`--image` only**. Use **`--material`** / `[@name]` when using a saved or community reference element (you may combine images and materials as long as the total stays in 1–7).
 - **Create References**: `vidu-cli element create --name ... --image ...` runs check → preprocess → create; returns element `id` and `version`.
 - **List personal references**: `vidu-cli element list [--keyword kw]`.
@@ -95,6 +97,8 @@ vidu-cli element search --keyword "keyword" [--pagesz 20]
 | `headtailimg2video` | Head and tail frames to video |
 | `reference2image` | Reference to image |
 | `character2video` | Reference to video |
+
+**Note**: `lip_sync` uses a different command: `vidu-cli task lip-sync` (not `task submit --type lip_sync`).
 
 ---
 
@@ -305,7 +309,55 @@ vidu-cli task submit \
   --resolution 2k
 ```
 
-### 7. Query task result
+### 7. lip-sync (口型同步)
+
+**Text mode (TTS with voice selection)**:
+
+```bash
+vidu-cli task lip-sync \
+  --video /path/to/video.mp4 \
+  --text "Hello, welcome to Vidu!" \
+  --voice-id English_Aussie_Bloke \
+  --speed 1.0 \
+  --volume 1.0 \
+  --codec h265
+```
+
+**Audio mode (custom audio file)**:
+
+```bash
+vidu-cli task lip-sync \
+  --video /path/to/video.mp4 \
+  --audio /path/to/audio.mp3 \
+  --codec h265
+```
+
+**Constraints**:
+- Video: MP4/MOV/AVI, ≤500MB
+- Audio: MP3/WAV/AAC/M4A, ≤100MB
+- Text: Chinese 2–1000 chars, English 4–2000 chars
+- `--text` and `--audio` are mutually exclusive (use one or the other)
+- `--speed`: 0.5–2.0 (default 1.0, text mode only)
+- `--volume`: 0.5–2.0 or 0 for server default (text mode only)
+- `--voice-id`: default `English_Aussie_Bloke` (90+ voices available, see voice list below)
+- Duration is auto-calculated from text length or audio file
+
+**Available voice IDs** (partial list, 90+ total):
+- English: `English_Aussie_Bloke`, `English_Trustworthy_Man`, `English_Graceful_Lady`, `English_Whispering_girl`, `English_Diligent_Man`, `English_Gentle-voiced_man`
+- Chinese: `male-qn-qingse`, `male-qn-jingying`, `male-qn-badao`, `male-qn-daxuesheng`, `female-shaonv`, `female-yujie`, `female-chengshu`, `female-tianmei`
+- Premium (精品): `male-qn-qingse-jingpin`, `female-shaonv-jingpin`, etc.
+- Cartoon: `clever_boy`, `cute_boy`, `lovely_girl`, `cartoon_pig`
+- Cantonese: `Cantonese_ProfessionalHost（F)`, `Cantonese_GentleLady`, `Cantonese_ProfessionalHost（M)`, `Cantonese_PlayfulMan`
+
+To get the complete list of all 90+ voice IDs:
+
+```bash
+vidu-cli task lip-sync-voices
+```
+
+Returns: `{"ok": true, "count": 90+, "voice_ids": [...]}`
+
+### 8. Query task result
 
 ```bash
 vidu-cli task get "$TASK_ID"
@@ -316,7 +368,7 @@ vidu-cli task get "$TASK_ID"
 - **failed**: `err_code`, `err_msg` — note `ok` may still be `true` with `state: failed`
 - **processing**: poll again later
 
-### 8. Task SSE (optional)
+### 9. Task SSE (optional)
 
 ```bash
 vidu-cli task sse "$TASK_ID"
@@ -324,7 +376,7 @@ vidu-cli task sse "$TASK_ID"
 
 Streams SSE to stdout; may produce large output.
 
-### 9. Image upload (optional)
+### 10. Image upload (optional)
 
 ```bash
 vidu-cli upload /path/to/image.jpg
@@ -392,6 +444,7 @@ Present results with `id`, `version`, `name`, `description`, `category` when ava
 - **image-to-video**: Describe motion or change, not only static description.
 - **head-tail-image-to-video**: Similar frames → smoother transition; very different frames → stronger morph.
 - **reference-to-image / reference-to-video**: **reference2image** and **character2video** both require a **non-empty text prompt**. **Image count + material count** must be **≥ 1 and ≤ 7**. You may use images only, materials only, or a mix; without `element create` when using images only. With a saved or community reference, use `[@reference_name]` and matching `--material`.
+- **lip-sync**: Choose text mode for TTS with voice selection, or audio mode for custom audio. Text mode auto-calculates duration from text length (Chinese: ~5 chars/sec, English: ~10 chars/sec). Audio mode reads duration from audio file metadata. Video must contain visible face/mouth for best results.
 
 ---
 


### PR DESCRIPTION
- Add lip-sync (口型同步) capability to vidu-skill
- Support two modes: text-to-speech (90+ voice IDs) and custom audio
- Add commands: task lip-sync, task lip-sync-voices
- Document constraints: video ≤500MB, audio ≤100MB
- Add usage examples and voice ID list
- Update version to 1.3.2