### PR TITLE
docs: add --video input and compose timeline required fields

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: vidu-skills
 description: Generate video and images by calling the official Vidu API via vidu CLI. Use when the user wants text-to-image, text-to-video, image-to-video, head-tail-image-to-video, reference-to-image, reference-to-video, lip-sync, text-to-speech, video-compose, Create References, or to submit or check Vidu tasks. Requires VIDU_TOKEN and optional VIDU_BASE_URL.
-version: 1.4.5
+version: 1.4.6
 homepage: https://www.vidu.cn/
 primaryEnv: VIDU_TOKEN
 metadata: {"openclaw":{"requires":{"bins":["node","npm","vidu-cli"],"env":["VIDU_TOKEN"]},"primaryEnv":"VIDU_TOKEN","install":[{"id":"vidu-cli","kind":"node","package":"vidu-cli","bins":["vidu-cli"],"label":"Install vidu-cli via npm (requires Node.js >=14; postinstall downloads a platform binary from GitHub)"}]}}
@@ -41,7 +41,7 @@ Generate AI videos and images with Vidu via `vidu-cli` — text-to-image, text-t
 | Command | Purpose |
 |---------|---------|
 | `vidu-cli upload <image_path>` | Upload image → `upload_id`, `ssupload_uri` |
-| `vidu-cli task submit --type ... --prompt ... [options]` | Submit task → `task_id`. `--image`: local path, URL, or `ssupload:?id=...` (auto-upload). |
+| `vidu-cli task submit --type ... --prompt ... [options]` | Submit task → `task_id`. `--image`: local path, URL, or `ssupload:?id=...` (auto-upload). `--video`: local path or `ssupload:?id=...` (character2video + 3.2_a only, auto-upload; URLs not supported). `--audio`: local path or `ssupload:?id=...` (character2video + 3.2_a only; URLs not supported). |
 | `vidu-cli task get <task_id> [--output/-o <dir>]` | Query task → `state`, `type`, `model`; use `--output` to download media on success |
 | `vidu-cli task compose --timeline <json> [--width N --height N] [--schedule-mode <mode>]` | Compose video from timeline → `task_id`. Query with `task get`. Supports `--schedule-mode` (auto-detected if omitted). **MUST read references/compose.md before building the timeline JSON — do not guess the schema.** |
 | `vidu-cli task lip-sync --video <path> --text <text> [options]` | Lip-sync with text-to-speech → `task_id`. Supports `--schedule-mode` (auto-detected if omitted). |
@@ -59,11 +59,17 @@ Generate AI videos and images with Vidu via `vidu-cli` — text-to-image, text-t
 | `vidu-cli element list [--keyword kw]` | List personal elements |
 | `vidu-cli element search --keyword kw` | Search community elements |
 
-**Smart image handling** (`task submit --image`, `element create --image`)
+**Smart input handling**
 
+`--image` (`task submit`, `element create`):
 - Local path → auto-upload (auto-compress when file is larger than 10MB)
 - `http(s):` URL → download then upload
 - `ssupload:?id=...` → use as-is
+
+`--video` and `--audio` (`task submit`, character2video + 3.2_a only):
+- Local path → auto-upload
+- `ssupload:?id=...` → use as-is
+- `http(s):` URL → **not supported** (rejected with error)
 
 ---
 
@@ -74,7 +80,7 @@ Generate AI videos and images with Vidu via `vidu-cli` — text-to-image, text-t
 - **image-to-video** — One image + text → video
 - **head-tail-image-to-video** — Start + end frames + text
 - **reference-to-image** — **Images + materials: 1–7** total; **text prompt required**; can be images-only, materials-only, or mixed; images-only needs no `element create`
-- **reference-to-video** — Same rule: **1–7** total; **text prompt required**
+- **reference-to-video** — Same rule: **1–7** total; **text prompt required**; with `3.2_a` model, also supports `--video` input (max 3, local files validated for size/dimensions/duration)
 - **lip-sync** — Drive video mouth movement with text-to-speech or audio file
 - **text-to-speech** — Convert text to speech audio via `task tts`
 - **video-compose** — Compose multi-track timeline (video/audio/subtitle/effect) into a single exported video via `task compose`
@@ -102,7 +108,7 @@ Content you send (prompts, images, task settings) goes to Vidu’s API. Confirm 
 ## Async workflow (short)
 
 - Vidu generation is **asynchronous**: `task submit` → **`task_id`** → poll **`task get <task_id>`** until terminal state.
-- **Model nicknames**: Q1 → `3.0`, Q2 → `3.1`, Q3 → `3.2`, Q3-A → `3.2_a` (character2video supports `--audio`; duration -1 or 4–15s). Additional variants exist: `3.1_pro`, `3.2_fast_m`, `3.2_pro_m`, `3.2_image_2` — see **references/parameters.md** for the complete per-task model version list.
+- **Model nicknames**: Q1 → `3.0`, Q2 → `3.1`, Q3 → `3.2`, Q3-A → `3.2_a` (character2video supports `--audio` and `--video`; duration -1 or 4–15s). Additional variants exist: `3.1_pro`, `3.2_fast_m`, `3.2_pro_m`, `3.2_image_2` — see **references/parameters.md** for the complete per-task model version list.
 - Task-type summaries, **task support matrix**, **copy-paste CLI examples**, **prompt tips**, and **element create/list/search** details are in **references/parameters.md**.
 - Task lifecycle, retries, and polling guidance: **references/errors_and_retry.md**.
 
@@ -113,7 +119,7 @@ Content you send (prompts, images, task settings) goes to Vidu’s API. Confirm 
 ### For task submit (generation tasks)
 
 1. Pick capability → map to `--type` and options using **references/parameters.md** (matrix + validation).
-2. Prepare inputs: for **reference2image** / **character2video**, `--image` and/or `--material` so **combined count is 1–7**; optional `[@name]` in prompt per **references/parameters.md**.
+2. Prepare inputs: for **reference2image** / **character2video**, `--image` and/or `--material` so **combined count is 1–7**; for **character2video** with `3.2_a`, also supports `--video` (max 3); optional `[@name]` in prompt per **references/parameters.md**.
 3. *(Optional)* Query cost before submitting: use `task cost`, `task tts-cost`, or `task lip-sync-cost` to estimate credit usage and check eligibility.
 4. `vidu-cli task submit ...` → store `task_id` and `trace_id`.
    - **schedule-mode auto-detection**: if `--schedule-mode` is omitted, CLI queries claw-pass status and uses `claw_pass` when user has an active pass, otherwise `normal`. If submit fails with `ClawPassExplicitModeRequired`, tell the user their daily claw-pass quota is exhausted. Do not retry automatically — suggest re-submitting with `--schedule-mode normal` to use credits instead, or waiting for the next quota refresh.
@@ -125,7 +131,7 @@ Content you send (prompts, images, task settings) goes to Vidu’s API. Confirm 
 **CRITICAL: Before constructing the `--timeline` JSON, you MUST read **references/compose.md** first.** The timeline has a specific JSON schema with exact field names, nesting structure, and media_url rules. Do NOT guess the structure — always refer to compose.md for the complete schema, supported fields, and examples.
 
 1. Read **references/compose.md** to understand the timeline JSON schema, media_url rules, and limits.
-2. Build the timeline JSON following the exact structure: `video_tracks[].video_track_clips[]`, `audio_tracks[].audio_track_clips[]`, `subtitle_tracks[].subtitle_track_clips[]`, `effect_tracks[].effect_track_items[]`.
+2. Build the timeline JSON following the exact structure: `video_tracks[].video_track_clips[]`, `audio_tracks[].audio_track_clips[]`, `subtitle_tracks[].subtitle_track_clips[]`, `effect_tracks[].effect_track_items[]`. Every clip **must** include `timeline_in` and `timeline_out` (the CLI validates this and rejects timelines with missing values).
 3. For `media_url`: use `ssupload:?id=xxx`, http URL, or local file path (auto-uploaded by CLI).
 4. For `file_url` (subtitles): use `ssupload:?id=xxx`, http URL, or local .srt file path.
 5. `vidu-cli task compose --timeline <file_or_json> [--width N --height N] [--schedule-mode <mode>]` → returns `task_id`.

--- a/references/compose.md
+++ b/references/compose.md
@@ -101,8 +101,8 @@ Top-level structure:
 | `in` | float | Entry point in source material (seconds) |
 | `out` | float | Exit point in source material (seconds) |
 | `duration` | float | Clip duration in seconds. **Required for `Image` and `GlobalImage` types** (specifies display time); optional for `Video` (derived from source if omitted). |
-| `timeline_in` | float | Start position on timeline |
-| `timeline_out` | float | End position on timeline |
+| `timeline_in` | float | Start position on timeline (**required**) |
+| `timeline_out` | float | End position on timeline (**required**) |
 | `speed` | float | Playback speed (0.1-100) |
 | `opacity` | float | 0 (transparent) to 1 (opaque) |
 | `effects` | Effect[] | Effects applied to this clip |
@@ -125,7 +125,7 @@ Top-level structure:
 | `content` | string | Text content (**required** for `AI_TTS` type; ignored for `Audio` type) |
 | `voice` | string | Voice identifier (**required** for `AI_TTS` type; ignored for `Audio` type) |
 | `in`, `out` | float | Trim points (seconds) |
-| `timeline_in`, `timeline_out` | float | Timeline positioning |
+| `timeline_in`, `timeline_out` | float | Timeline positioning (**required**) |
 | `speed` | float | Playback speed (0.1-100) |
 | `loop_mode` | boolean | If `true`, the audio loops to fill the duration between `timeline_in` and `timeline_out`. If `false` or omitted, audio plays once and stops. |
 | `effects` | Effect[] | Effects applied to this clip |
@@ -150,7 +150,7 @@ Top-level structure:
 | `font_color_opacity` | float | 0-1 |
 | `font_face` | object | `{ bold, italic, underline }` (booleans) |
 | `x`, `y` | float | Position |
-| `timeline_in`, `timeline_out` | float | Display duration |
+| `timeline_in`, `timeline_out` | float | Timeline positioning (**required**) |
 | `alignment` | string | TopLeft, TopCenter, TopRight, CenterLeft, CenterCenter, CenterRight, BottomLeft, BottomCenter (default), BottomRight |
 | `adapt_mode` | string | AutoWrap, AutoScale, AutoWrapAtSpaces |
 | `spacing` | int | Character spacing (pixels) |
@@ -169,8 +169,8 @@ Top-level structure:
 |-------|------|-------------|
 | `type` | string | `VFX` or `Filter` |
 | `sub_type` | string | Specific effect subtype |
-| `timeline_in` | float | Start position |
-| `timeline_out` | float | End position |
+| `timeline_in` | float | Start position (**required**) |
+| `timeline_out` | float | End position (**required**) |
 | `duration` | float | Effect duration |
 | `x`, `y`, `width`, `height` | float | Effect region (for mosaic/blur) |
 

--- a/references/parameters.md
+++ b/references/parameters.md
@@ -13,7 +13,7 @@ Daily use: **`vidu-cli`** flags and the sections below.
 | img2video | `img2video` | 3.0, 3.1, 3.2, 3.2_a | 3.0: 5s; 3.1: 2–8s; 3.2: 1–16s; 3.2_a: -1 or 4–15s | 1080p | from image (do not pass) | 3.0: creative/stable; 3.1+: pro/speed | exactly 1 |
 | headtailimg2video | `headtailimg2video` | 3.0, 3.1, 3.2, 3.2_a | 3.0: 5s; 3.1: 2–8s; 3.2: 1–16s; 3.2_a: -1 or 4–15s | 1080p | N/A | 3.0: creative/stable; 3.1+: pro/speed | exactly 2 |
 | reference2image | `reference2image` | 3.1, 3.2_fast_m, 3.2_pro_m, 3.2_image_2 | 0 | 1080p, 2k, 4k | 4:3, 3:4, 1:1, 9:16, 16:9 | N/A | images + materials: 1–7 |
-| character2video | `character2video` | 3.0, 3.1, 3.1_pro, 3.2, 3.2_a | 3.0: 5s; 3.1: 2–8s; 3.1_pro: -1/2–8s; 3.2: 1–16s; 3.2_a: -1 or 4–15s | 1080p | 16:9, 9:16, 1:1, 4:3, 3:4 | 3.2: **pro/speed (required)**; 3.2_a: do not pass | images + materials: 1–7; 3.2_a also supports `--audio` (≤3, wav/mp3, ≤15MB each, each 2–15s, total ≤15s) |
+| character2video | `character2video` | 3.0, 3.1, 3.1_pro, 3.2, 3.2_a | 3.0: 5s; 3.1: 2–8s; 3.1_pro: -1/2–8s; 3.2: 1–16s; 3.2_a: -1 or 4–15s | 1080p | 16:9, 9:16, 1:1, 4:3, 3:4 | 3.2: **pro/speed (required)**; 3.2_a: do not pass | images + materials: 1–7; 3.2_a also supports `--audio` (≤3, wav/mp3, ≤15MB each, each 2–15s, total ≤15s) and `--video` (mp4/mov; max 3; local files: ≤50MB each, aspect ratio 0.4–2.5, w/h 300–60000, total pixels 409600–2086876, total duration ≤15s) |
 | lip_sync | `task lip-sync` | N/A | auto (from text/audio) | 1080p | from video | N/A | 1 video + (text OR audio) |
 | tts | `task tts` | N/A | auto (from text) | N/A | N/A | N/A | text + voice-id |
 
@@ -52,7 +52,8 @@ vidu-cli task submit \
   --prompt "text prompt" \
   [--image <path|url|ssupload_uri>] \
   [--material "name:id:version"] \
-  [--audio <path|url|ssupload_uri>] \
+  [--audio <path|ssupload_uri>] \
+  [--video <path|ssupload_uri>] \
   --duration <seconds> \
   --model-version <version> \
   [--aspect-ratio <ratio>] \
@@ -64,7 +65,7 @@ vidu-cli task submit \
   [--schedule-mode <mode>]
 ```
 
-`--image` and `--material` may be repeated where applicable. `--audio` may be repeated (character2video + 3.2_a only, max 3).
+`--image` and `--material` may be repeated where applicable. `--audio` may be repeated (character2video + 3.2_a only, max 3). `--video` may be repeated (character2video + 3.2_a only, max 3, total local video duration ≤ 15s).
 
 ### Query task
 
@@ -147,7 +148,7 @@ vidu-cli quota credit
 | `3.0` | Q1 | |
 | `3.1` | Q2 | text2image, reference2image, 2–8s video models |
 | `3.2` | Q3 | 1–16s video models |
-| `3.2_a` | Q3-A | text2video, img2video, headtailimg2video, character2video; duration -1 (auto) or 4–15s; supports `--audio` for character2video **only** (invalid for all other model versions and task types) |
+| `3.2_a` | Q3-A | text2video, img2video, headtailimg2video, character2video; duration -1 (auto) or 4–15s; supports `--audio` for character2video **only** (invalid for all other model versions and task types); supports `--video` for character2video **only** (max 3; local file constraints: mp4/mov, ≤50MB, aspect ratio 0.4–2.5, w/h 300–60000, total pixels 409600–2086876, total duration ≤15s) |
 | `3.1_pro` | Q2 pro | `character2video` only |
 | `3.2_fast_m` | Q3 fast | text2image / reference2image only |
 | `3.2_pro_m` | Q3 pro | text2image / reference2image only |
@@ -334,6 +335,22 @@ vidu-cli task submit \
 - `--image`: additional scene/style reference image (local path, URL, or `ssupload:?id=...`)
 - `--audio`: reference audio files (wav/mp3, ≤15MB each, 2–15s each, max 3, total ≤15s)
 - `--duration -1`: model auto-infers output duration from inputs
+
+**With 3.2_a model — video as reference input**:
+
+```bash
+vidu-cli task submit \
+  --type character2video \
+  --prompt "[@aliya] dances gracefully in the studio" \
+  --material "aliya:3073530415201165:1765430214" \
+  --video /path/to/dance_ref.mp4 \
+  --duration -1 \
+  --model-version 3.2_a \
+  --aspect-ratio 16:9 \
+  --resolution 1080p
+```
+
+- `--video`: reference video (mp4/mov; local path or `ssupload:?id=...`; HTTP/HTTPS URLs not supported). Max 3. Local files: ≤50MB, aspect ratio 0.4–2.5, w/h 300–60000, total pixels 409600–2086876, total local video duration ≤15s.
 
 **Reference + extra image(s)** — mixed `--material` and `--image` (repeat either flag; combined count ≤ 7):
 
@@ -691,7 +708,8 @@ All commands return one JSON line on stdout.
 - Do not pass `aspect_ratio` for **img2video** / **headtailimg2video** when disallowed.
 - Do not pass `transition` for reference tasks or **text2image**.
 - For **reference2image** and **character2video**: **image count + material count** in **1–7** (inclusive); **non-empty text prompt required**. Violating either constraint causes a validation error.
-- **`--audio`** (`character2video` with `3.2_a` only): max 3 audio inputs; each must be wav/mp3, ≤15MB, duration 2–15s; total duration of all audio inputs ≤15s. Passing `--audio` with any other task type or model_version causes a validation error. Accepts local path, URL, or `ssupload:?id=...` (local files are validated; remote URIs are passed through).
+- **`--audio`** (`character2video` with `3.2_a` only): max 3 audio inputs; each must be wav/mp3, ≤15MB, duration 2–15s; total duration of all audio inputs ≤15s. Passing `--audio` with any other task type or model_version causes a validation error. Accepts local path or `ssupload:?id=...` (HTTP/HTTPS URLs not supported; local files are validated).
+- **`--video`** (`character2video` with `3.2_a` only): max 3 video inputs. Passing `--video` with any other task type or model_version causes a validation error. Accepts local path or `ssupload:?id=...` (HTTP/HTTPS URLs not supported). **Local file validation**: format must be mp4 or mov; single file ≤ 50MB; aspect ratio (width ÷ height) must be in [0.4, 2.5]; width and height each in [300, 60000]; total pixels (width × height) must be in [409600, 2086876]; total duration of all local video inputs ≤ 15s.
 - API-level `input.enhance` / recaption: **no manual CLI field** — rely on `vidu-cli` defaults.
 - `--schedule-mode`: valid values are `claw_pass` and `normal`. If omitted, auto-detected by querying claw-pass status.
 


### PR DESCRIPTION
## Summary

Update documentation for vidu-cli `--video` input support and compose timeline validation.

## Changes

### SKILL.md
- Commands table: add `--video` to `task submit` description
- Key Capabilities: update reference-to-video with `--video` support for 3.2_a
- Model nicknames: add `--video` alongside `--audio` for 3.2_a
- Implementation guide: add `--video` to input preparation step
- Compose guide: note `timeline_in`/`timeline_out` are required for every clip
- Rename "Smart image handling" → "Smart input handling" covering `--video`/`--audio`

### references/parameters.md
- Task support matrix: add `--video` constraints for character2video + 3.2_a
- CLI synopsis: add `--video` flag
- Model version table: add `--video` note for 3.2_a
- Validation rules: add `--video` local file constraints
- CLI examples: add character2video + 3.2_a + video example

### references/compose.md
- Mark `timeline_in`/`timeline_out` as **required** for all clip types

Version bump: 1.4.5 → 1.4.6