### PR TITLE
docs: document --prompt-path for task submit and task tts

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,12 +90,12 @@ vidu-cli task tts-voices
 | Command | Purpose |
 |---------|---------|
 | `vidu-cli upload <image>` | Upload image, returns `upload_id` |
-| `vidu-cli task submit --type ... --prompt ...` | Submit task, returns `task_id` |
+| `vidu-cli task submit --type ... [--prompt ... | --prompt-path ...]` | Submit task, returns `task_id` |
 | `vidu-cli task get <task_id> [--output dir]` | Query task status, optionally download result |
 | `vidu-cli task compose --timeline <json>` | Video compose, returns `task_id` |
 | `vidu-cli task lip-sync --video ... --text ...` | Lip sync (TTS mode) |
 | `vidu-cli task lip-sync --video ... --audio ...` | Lip sync (audio file mode) |
-| `vidu-cli task tts --prompt ... --voice-id ...` | Text-to-speech |
+| `vidu-cli task tts [--prompt ... | --prompt-path ... | --text ...] --voice-id ...` | Text-to-speech |
 | `vidu-cli element create --name ... --image ... [--description ...] [--style ...]` | Create reference element |
 | `vidu-cli element check --name ...` | Check element name availability |
 | `vidu-cli element list [--keyword kw]` | List personal elements |

--- a/README.zh.md
+++ b/README.zh.md
@@ -90,12 +90,12 @@ vidu-cli task tts-voices
 | 命令 | 用途 |
 |------|------|
 | `vidu-cli upload <image>` | 上传图片，返回 `upload_id` |
-| `vidu-cli task submit --type ... --prompt ...` | 提交任务，返回 `task_id` |
+| `vidu-cli task submit --type ... [--prompt ... | --prompt-path ...]` | 提交任务，返回 `task_id` |
 | `vidu-cli task get <task_id> [--output dir]` | 查询任务状态，可下载结果 |
 | `vidu-cli task compose --timeline <json>` | 视频合成，返回 `task_id` |
 | `vidu-cli task lip-sync --video ... --text ...` | 口型同步（TTS 模式） |
 | `vidu-cli task lip-sync --video ... --audio ...` | 口型同步（音频模式） |
-| `vidu-cli task tts --prompt ... --voice-id ...` | 文字转语音 |
+| `vidu-cli task tts [--prompt ... | --prompt-path ... | --text ...] --voice-id ...` | 文字转语音 |
 | `vidu-cli element create --name ... --image ... [--description ...] [--style ...]` | 创建参考素材 |
 | `vidu-cli element check --name ...` | 检查素材名称可用性 |
 | `vidu-cli element list [--keyword kw]` | 列出个人素材 |

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: vidu-skills
 description: Generate video and images by calling the official Vidu API via vidu CLI. Use when the user wants text-to-image, text-to-video, image-to-video, head-tail-image-to-video, reference-to-image, reference-to-video, lip-sync, text-to-speech, video-compose, Create References, or to submit or check Vidu tasks. Requires VIDU_TOKEN and optional VIDU_BASE_URL.
-version: 1.4.10
+version: 1.4.11
 homepage: https://www.vidu.cn/
 primaryEnv: VIDU_TOKEN
 metadata: {"openclaw":{"requires":{"bins":["node","npm","vidu-cli"],"env":["VIDU_TOKEN"]},"primaryEnv":"VIDU_TOKEN","install":[{"id":"vidu-cli","kind":"node","package":"vidu-cli","bins":["vidu-cli"],"label":"Install vidu-cli via npm (requires Node.js >=14; postinstall downloads a platform binary from GitHub)"}]}}
@@ -41,13 +41,13 @@ Generate AI videos and images with Vidu via `vidu-cli` — text-to-image, text-t
 | Command | Purpose |
 |---------|---------|
 | `vidu-cli upload <image_path>` | Upload image → `upload_id`, `ssupload_uri` |
-| `vidu-cli task submit --type ... --prompt ... [options]` | Submit task → `task_id`. `--image`: local path, URL, or `ssupload:?id=...` (auto-upload). `--video`: local path or `ssupload:?id=...` (character2video + 3.2_a only, auto-upload; URLs not supported). `--audio`: local path or `ssupload:?id=...` (character2video + 3.2_a only; URLs not supported). |
+| `vidu-cli task submit --type ... [--prompt TEXT \| --prompt-path PATH] [options]` | Submit task → `task_id`. `--prompt` is inline text; `--prompt-path` reads a UTF-8 file (≤1MiB). When both are given, `--prompt` wins. `--image`: local path, URL, or `ssupload:?id=...` (auto-upload). `--video`: local path or `ssupload:?id=...` (character2video + 3.2_a only, auto-upload; URLs not supported). `--audio`: local path or `ssupload:?id=...` (character2video + 3.2_a only; URLs not supported). |
 | `vidu-cli task get <task_id> [--output/-o <dir>]` | Query task → `state`, `type`, `model`; use `--output` to download media on success |
 | `vidu-cli task compose --timeline <json> [--width N --height N] [--schedule-mode <mode>]` | Compose video from timeline → `task_id`. Query with `task get`. Supports `--schedule-mode` (auto-detected if omitted). **MUST read references/compose.md before building the timeline JSON — do not guess the schema.** |
 | `vidu-cli task lip-sync --video <path> --text <text> [options]` | Lip-sync with text-to-speech → `task_id`. Supports `--schedule-mode` (auto-detected if omitted). |
 | `vidu-cli task lip-sync --video <path> --audio <path>` | Lip-sync with audio file → `task_id`. Supports `--schedule-mode` (auto-detected if omitted). |
 | `vidu-cli task lip-sync-voices` | List available lip-sync voices (90+, Chinese/English/Cantonese/Cartoon etc.) |
-| `vidu-cli task tts --prompt ... --voice-id ...` | Text-to-speech → `task_id`. Supports `--schedule-mode` (auto-detected if omitted). |
+| `vidu-cli task tts [--prompt TEXT \| --prompt-path PATH] --voice-id ...` | Text-to-speech → `task_id`. `--prompt` is inline text; `--prompt-path` reads a UTF-8 file (≤1MiB). Multi-segment `--text` remains supported. `--prompt` wins when both are given. `--prompt-path` is mutually exclusive with `--text`. Supports `--schedule-mode` (auto-detected if omitted). |
 | `vidu-cli task tts-voices` | List available TTS voices (300+, 20+ languages) |
 | `vidu-cli task cost --type ... --model-version ... --duration ...` | Query credit cost for video/image tasks (estimate before submitting) |
 | `vidu-cli task tts-cost --text ... --voice-id ...` | Query credit cost for TTS tasks (priced by character count; `--text` required) |

--- a/references/parameters.md
+++ b/references/parameters.md
@@ -23,9 +23,9 @@ Daily use: **`vidu-cli`** flags and the sections below.
 - **text-to-video**: Text only.
 - **image-to-video**: One image + text; aspect ratio comes from the image.
 - **head-tail-image-to-video**: Two images (start, end) + text.
-- **reference2image** and **character2video** — same input rule: **image count + material count must be ≥ 1 and ≤ 7** (each `--image` and each `--material` counts toward the total). **Text prompt (`--prompt`) is required** for both (cannot omit or leave empty).
+- **reference2image** and **character2video** — same input rule: **image count + material count must be ≥ 1 and ≤ 7** (each `--image` and each `--material` counts toward the total). **Text prompt (`--prompt` or `--prompt-path`) is required** for both (cannot omit or leave empty).
 - **lip-sync**: Drive video mouth movement with text-to-speech or audio file. Two modes: **text mode** (TTS with voice selection) or **audio mode** (custom audio file). Video: MP4/MOV/AVI, ≤500MB. Audio: MP3/WAV/AAC/M4A, ≤100MB.
-- **TTS**: Convert text to speech audio. Uses `task tts` command (not `task submit`). Requires `--prompt` and `--voice-id`. List voices with `task tts-voices`.
+- **TTS**: Convert text to speech audio. Uses `task tts` command (not `task submit`). Requires `--voice-id` and one of `--prompt`, `--prompt-path`, or `--text`. `--prompt` / `--prompt-path` are for single-segment input; `--text` is for multi-segment input. List voices with `task tts-voices`.
 - **When is `element create` needed?** `element create` saves a reference for **future reuse** across multiple tasks. It is **not required** for one-off generation — just pass `--image` directly. Use `--material` (with `[@name]` in prompt) only when referencing a **previously saved** or **community** element. You may combine `--image` and `--material` as long as the total stays in 1–7.
 - **Create References**: `vidu-cli element create --name ... --image ...` runs check → preprocess → create; returns element `id` and `version`.
 - **List personal references**: `vidu-cli element list [--keyword kw]`.
@@ -203,10 +203,32 @@ Use **`vidu-cli` flags only** — do not hand-craft request bodies or invent ext
 
 | CLI | Role |
 |-----|------|
-| `--prompt` | Text prompt (respect length limits, e.g. up to 4096 chars) |
+| `--prompt` | Inline text prompt (respect length limits, e.g. up to 4096 chars). Use `--prompt-path <path>` to load the prompt from a file instead. When both flags are passed, `--prompt` wins. |
+| `--prompt-path` | Read the prompt from a UTF-8 file (≤1MiB; one trailing newline is stripped). Available wherever `--prompt` is documented (`task submit`, `task tts`). |
 | `--image` | Images (paths, URLs, or `ssupload` URIs after upload) |
 | `--material` | Reference material ids |
 | `input.enhance` / recaption | **No CLI flag** — handled internally by `vidu-cli` (do not invent a flag). |
+
+---
+
+### Prompt input formats
+
+Wherever `--prompt` is supported, you can pass the prompt as inline text or as a file:
+
+- **Inline text** — `--prompt "A cat walks in the snow"`
+- **From a file** — `--prompt-path prompts/scene.txt`
+
+`--prompt-path` requires a UTF-8 file ≤1 MiB; one trailing newline is stripped. When both `--prompt` and `--prompt-path` are passed, `--prompt` wins (no warning is emitted). On `task tts`, `--prompt-path` is mutually exclusive with `--text`.
+
+```bash
+echo 'A neon-lit alley after the rain' > prompts/alley.txt
+vidu-cli task submit \
+  --type text2video \
+  --prompt-path prompts/alley.txt \
+  --duration 5 \
+  --model-version 3.2 \
+  --resolution 1080p
+```
 
 ---
 
@@ -386,7 +408,7 @@ vidu-cli task submit \
 
 ### 6. reference-to-image
 
-Same limits as **character2video**: **images + materials between 1 and 7**, **non-empty `--prompt` required**.
+Same limits as **character2video**: **images + materials between 1 and 7**, **non-empty prompt text is required** (`--prompt` or `--prompt-path`).
 
 **With a saved reference:**
 
@@ -413,7 +435,7 @@ vidu-cli task submit \
   --resolution 2k
 ```
 
-**Images only (no subject)** — still must pass `--prompt`:
+**Images only (no subject)** — still must pass prompt text (`--prompt` or `--prompt-path`):
 
 ```bash
 vidu-cli task submit \
@@ -488,7 +510,9 @@ vidu-cli task tts \
 
 | Parameter | Required | Default | Range | Description |
 |-----------|----------|---------|-------|-------------|
-| `--prompt` | Yes | - | 1-2000 chars | Text to convert to speech |
+| `--prompt` | One of\* | - | 1-2000 chars | Inline text to convert to speech. |
+| `--prompt-path` | One of\* | - | UTF-8 file ≤1MiB | Read the prompt from a file (one trailing newline stripped). Ignored when `--prompt` is also set. Mutually exclusive with `--text`. |
+| `--text` | One of\* | - | 1-20 segments | Repeatable segment input for multi-segment TTS. Mutually exclusive with `--prompt` and `--prompt-path`. |
 | `--voice-id` | Yes | - | See tts-voices | Voice ID. Voice IDs from `tts-voices` only; do not use `lip-sync-voices` IDs here — using wrong pool causes a validation error. |
 | `--speed` | No | 1.0 | 0.5-2.0 | Speed multiplier (values outside range cause validation error) |
 | `--volume` | No | 80 | 0-100 | Volume level (values outside range cause validation error) |


### PR DESCRIPTION
## Summary

Pairs with shengshu-ai/vidu-cli#25, which adds the `--prompt-path` flag for `task submit` and `task tts`. This PR updates the skill docs so the agent can explain and demonstrate the new flag.

## Behavior to document

- `--prompt` is inline text; `--prompt-path` reads the prompt from a UTF-8 file (≤1 MiB; one trailing newline is stripped).
- When both flags are given, `--prompt` wins (no warning emitted).

## Files touched

- `SKILL.md`: command table rows for `task submit` and `task tts` rewritten as `[--prompt TEXT | --prompt-path PATH]`, with the precedence note.
- `references/parameters.md`:
  - CLI vs raw JSON table: `--prompt` row updated, new `--prompt-path` row added.
  - New `Prompt input formats` subsection with an inline / file example.
  - TTS parameter table: `--prompt` marked `Yes*` and a `--prompt-path` row added (one-of-required).

## Notes

`--text` is intentionally not changed in this PR; the multi-segment workflow stays as-is. Land after the CLI PR so the docs don't reference a flag that isn't shipped yet.