### PR TITLE
unify TTS and lip-sync voice pool documentation

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -57,7 +57,6 @@ Never use these:
 - `reference2image` and `character2video` require non-empty prompt plus 1-7 total references (`--image` + `--material`).
 - Image tasks use `--duration 0`; reusable `element create` has no `duration`.
 - For `character2video` with `3.2_a`, duration must be an explicit `4-15`; for other models, check `references/parameters.md`.
-- TTS subtitle output is enabled by default for single `--prompt` or `--prompt-path`; use `--subtitle-enable false` to disable it. Multi-segment `--text` mode currently requires `--subtitle-enable false`.
 - Download successful media with `vidu-cli task get <task_id> --output <dir>`; when `subtitle_uri` is present, this also downloads subtitle JSON.
 - Report CLI/API errors from JSON fields exactly; do not infer hidden causes.
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -70,7 +70,7 @@ vidu-cli task submit --type reference2image --prompt "..." --image /path/a.png -
 
 vidu-cli task submit --type character2video --prompt "[@角色A] walks into office" --material "角色A:ID:VERSION" --duration 5 --model-version 3.2_a --resolution 1080p
 
-vidu-cli task tts --prompt "旁白文本" --voice-id Chinese_Mandarin_Gentleman --speed 1.3
+vidu-cli task tts --prompt "旁白文本" --voice-id "Chinese (Mandarin)_Gentleman" --speed 1.3
 ```
 
 ## Load References Only When Needed

--- a/references/parameters.md
+++ b/references/parameters.md
@@ -197,7 +197,7 @@ vidu-cli quota credit
 
 ## CLI settings (`task submit`)
 
-### `--model-version` (required)
+### `--model-version` (alias `--model`) (required)
 
 | Value | Maps to | Notes |
 |-------|---------|-------|
@@ -563,7 +563,7 @@ vidu-cli task lip-sync \
 - `--text` and `--audio` are mutually exclusive (use one or the other)
 - `--speed`: 0.5–2.0 (default 1.0, text mode only)
 - `--volume`: 0.1–2.0, or 0 for server default (text mode only)
-- `--voice-id`: default `English_Aussie_Bloke` (250+ voices available, see voice list below). Voice IDs from `tts-voices` or `lip-sync-voices` (same pool).
+- `--voice-id` (alias `--voice`): default `English_Aussie_Bloke` (250+ voices available).
 - `--schedule-mode`: `claw_pass` (use daily quota) or `normal` (use credits). Optional — auto-detected from claw-pass status if omitted.
 - Duration is auto-calculated from text length or audio file
 
@@ -585,7 +585,6 @@ TTS is its own subcommand. Do not use `task submit --type tts`.
 vidu-cli task tts \
   --prompt "text" \
   --voice-id "Chinese (Mandarin)_Reliable_Executive" \
-  --subtitle-enable \
   --speed 1.0 \
   --volume 80 \
   --emotion "happy" \
@@ -605,12 +604,12 @@ Do not use `sh -c`, shell command substitution, or `$(cat file)` for TTS. If the
 | `--prompt` | One of\* | - | 1-2000 chars | Inline text to convert to speech. |
 | `--prompt-path` | One of\* | - | UTF-8 file ≤1MiB | Read the prompt from a file (one trailing newline stripped). Ignored when `--prompt` is also set. Mutually exclusive with `--text`. |
 | `--text` | One of\* | - | 1-20 segments | Repeatable segment input for multi-segment TTS. Mutually exclusive with `--prompt` and `--prompt-path`. |
-| `--voice-id` | Yes | - | See tts-voices | Voice ID. Voice IDs from `tts-voices` or `lip-sync-voices` (same pool). |
+| `--voice-id` | Yes | - | See tts-voices | Voice ID. Alias: `--voice`. |
 | `--speed` | No | 1.0 | 0.5-2.0 | Speed multiplier (values outside range cause validation error) |
 | `--volume` | No | 80 | 0-100 | Volume level (values outside range cause validation error) |
 | `--emotion` | No | - | Any text | Emotion hint |
 | `--language-boost` | No | - | Chinese, English, auto | Enhance specific language recognition |
-| `--subtitle-enable` | No | true | true/false | Enable subtitle JSON output. Omitted means true; `--subtitle-enable` and `--subtitle-enable true` are equivalent; use `--subtitle-enable false` to disable it. First version supports subtitle output only with single `--prompt`, so multi-segment `--text` mode requires `--subtitle-enable false`. |
+| `--subtitle-enable` | No | true | true/false | Enable subtitle JSON output. Works with `--prompt` and single `--text`; errors on multi-segment `--text`. |
 | `--schedule-mode` | No | auto | claw_pass, normal | Schedule mode: `claw_pass` (use daily quota) or `normal` (use credits). Auto-detected from claw-pass status if omitted. |
 
 List available voices: `vidu-cli task tts-voices` (grouped by language with count)

--- a/references/parameters.md
+++ b/references/parameters.md
@@ -45,9 +45,9 @@ Daily use: **`vidu-cli`** flags and the sections below.
 | `vidu-cli task compose --timeline <json-or-file> [--width N --height N] [--schedule-mode <mode>]` | Compose a video timeline. Read `compose.md` before building the timeline schema. |
 | `vidu-cli task lip-sync --video <path> --text <text> [options]` | Lip-sync with text-to-speech voice selection. |
 | `vidu-cli task lip-sync --video <path> --audio <path>` | Lip-sync with a custom audio file. |
-| `vidu-cli task lip-sync-voices` | List lip-sync voice IDs. Do not use TTS voice IDs for lip-sync. |
+| `vidu-cli task lip-sync-voices` | List available voice IDs (same pool as tts-voices). |
 | `vidu-cli task tts [--prompt TEXT \| --prompt-path PATH \| --text TEXT] --voice-id ...` | Text-to-speech; returns `task_id`. |
-| `vidu-cli task tts-voices` | List TTS voice IDs. Do not use lip-sync voice IDs for TTS. |
+| `vidu-cli task tts-voices` | List available voice IDs (same pool as lip-sync-voices). |
 | `vidu-cli task cost --type ... --model-version ... --duration ...` | Estimate video/image task credit cost. |
 | `vidu-cli task tts-cost --text ... --voice-id ...` | Estimate TTS credit cost. |
 | `vidu-cli task lip-sync-cost --duration ... [--voice-id ...]` | Estimate lip-sync credit cost. |
@@ -563,24 +563,17 @@ vidu-cli task lip-sync \
 - `--text` and `--audio` are mutually exclusive (use one or the other)
 - `--speed`: 0.5–2.0 (default 1.0, text mode only)
 - `--volume`: 0.1–2.0, or 0 for server default (text mode only)
-- `--voice-id`: default `English_Aussie_Bloke` (90+ voices available, see voice list below). Voice IDs from `lip-sync-voices` only; do not use `tts-voices` IDs here — using wrong pool causes a validation error.
+- `--voice-id`: default `English_Aussie_Bloke` (250+ voices available, see voice list below). Voice IDs from `tts-voices` or `lip-sync-voices` (same pool).
 - `--schedule-mode`: `claw_pass` (use daily quota) or `normal` (use credits). Optional — auto-detected from claw-pass status if omitted.
 - Duration is auto-calculated from text length or audio file
 
-**Available voice IDs** (partial list, 90+ total):
-- English: `English_Aussie_Bloke`, `English_Trustworthy_Man`, `English_Graceful_Lady`, `English_Whispering_girl`, `English_Diligent_Man`, `English_Gentle-voiced_man`
-- Chinese: `male-qn-qingse`, `male-qn-jingying`, `male-qn-badao`, `male-qn-daxuesheng`, `female-shaonv`, `female-yujie`, `female-chengshu`, `female-tianmei`
-- Premium: `male-qn-qingse-jingpin`, `female-shaonv-jingpin`, etc.
-- Cartoon: `clever_boy`, `cute_boy`, `lovely_girl`, `cartoon_pig`
-- Cantonese: `Cantonese_ProfessionalHost（F)`, `Cantonese_GentleLady`, `Cantonese_ProfessionalHost（M)`, `Cantonese_PlayfulMan`
-
-To get the complete list of all 90+ voice IDs:
+**Available voice IDs**: 250+ voices across Chinese, English, Japanese, Korean, Spanish, Portuguese, and more. TTS and lip-sync share the same voice pool. List all available voices:
 
 ```bash
-vidu-cli task lip-sync-voices
+vidu-cli task tts-voices
 ```
 
-Returns: `{"ok": true, "count": 90+, "voice_ids": [...]}`
+Returns voices grouped by language.
 
 ### 8. TTS (Text-to-Speech)
 
@@ -612,7 +605,7 @@ Do not use `sh -c`, shell command substitution, or `$(cat file)` for TTS. If the
 | `--prompt` | One of\* | - | 1-2000 chars | Inline text to convert to speech. |
 | `--prompt-path` | One of\* | - | UTF-8 file ≤1MiB | Read the prompt from a file (one trailing newline stripped). Ignored when `--prompt` is also set. Mutually exclusive with `--text`. |
 | `--text` | One of\* | - | 1-20 segments | Repeatable segment input for multi-segment TTS. Mutually exclusive with `--prompt` and `--prompt-path`. |
-| `--voice-id` | Yes | - | See tts-voices | Voice ID. Voice IDs from `tts-voices` only; do not use `lip-sync-voices` IDs here — using wrong pool causes a validation error. |
+| `--voice-id` | Yes | - | See tts-voices | Voice ID. Voice IDs from `tts-voices` or `lip-sync-voices` (same pool). |
 | `--speed` | No | 1.0 | 0.5-2.0 | Speed multiplier (values outside range cause validation error) |
 | `--volume` | No | 80 | 0-100 | Volume level (values outside range cause validation error) |
 | `--emotion` | No | - | Any text | Emotion hint |
@@ -688,7 +681,7 @@ vidu-cli task lip-sync-cost \
 | Parameter | Required | Default | Description |
 |-----------|----------|---------|-------------|
 | `--duration` | No | - | Duration in seconds (required for video tasks; optional for image tasks) |
-| `--voice-id` | No | English_Aussie_Bloke | Voice ID (from `task lip-sync-voices`) |
+| `--voice-id` | No | English_Aussie_Bloke | Voice ID (from `task tts-voices`) |
 | `--speed` | No | 1.0 | Speech speed: 0.5-2.0 |
 | `--volume` | No | 0 | Volume [0.5,2], or 0 for server default |
 | `--codec` | No | h265 | Codec |

--- a/references/parameters.md
+++ b/references/parameters.md
@@ -607,7 +607,7 @@ Do not use `sh -c`, shell command substitution, or `$(cat file)` for TTS. If the
 | `--voice-id` | Yes | - | See tts-voices | Voice ID. Alias: `--voice`. |
 | `--speed` | No | 1.0 | 0.5-2.0 | Speed multiplier (values outside range cause validation error) |
 | `--volume` | No | 80 | 0-100 | Volume level (values outside range cause validation error) |
-| `--emotion` | No | - | Any text | Emotion hint |
+| `--emotion` | No | - | happy, sad, angry, fearful, disgusted, surprised, calm | Emotion hint for expressive speech |
 | `--language-boost` | No | - | Chinese, English, auto | Enhance specific language recognition |
 | `--subtitle-enable` | No | true | true/false | Enable subtitle JSON output. Works with `--prompt` and single `--text`; errors on multi-segment `--text`. |
 | `--schedule-mode` | No | auto | claw_pass, normal | Schedule mode: `claw_pass` (use daily quota) or `normal` (use credits). Auto-detected from claw-pass status if omitted. |


### PR DESCRIPTION
- Fix SKILL.md example: Chinese_Mandarin_Gentleman -> Chinese (Mandarin)_Gentleman
- Remove 'Do not use TTS voice IDs for lip-sync' / 'Do not use lip-sync voice IDs for TTS' warnings
- Lip-sync voice list now points to tts-voices (same pool)
- Aligns with server-side behavior and vidu-cli voice list merge